### PR TITLE
add autogenerated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.pyc
 *.pyo
 .DS_Store
+build/
+dist/
+pyopenfec.egg-info/


### PR DESCRIPTION
When I'm developing locally (python 3.4.5 on OSX) the following directories are autogenerated when I run `setup.py`:

- build/
- dist/
- pyopenfec.egg-info/

This PR adds those to the .gitignore so that we can avoid accidentally adding them to version control.