### PR TITLE
Make date fields be datetime objects

### DIFF
--- a/pyopenfec/aggregates.py
+++ b/pyopenfec/aggregates.py
@@ -75,8 +75,13 @@ class CommitteeTotals(utils.PyOpenFecApiPaginatedClass):
         self.transfers_to_affiliated_committee = None
         self.transfers_to_other_authorized_committee = None
 
+        date_fields = {
+            'coverage_start_date': '%Y-%m-%dT%H:%M:%S+00:00',
+            'coverage_end_date': '%Y-%m-%dT%H:%M:%S+00:00',
+            }
+
         for k, v in kwargs.items():
-            setattr(self, k, v)
+            utils.set_instance_attr(self, k, v, date_fields)
 
     def __unicode__(self):
         return unicode("{cid} totals ({c} cycle, {csd}-{ced})".format(

--- a/pyopenfec/candidate.py
+++ b/pyopenfec/candidate.py
@@ -25,8 +25,15 @@ class Candidate(utils.PyOpenFecApiPaginatedClass, utils.SearchMixin):
         self._history = None
         self._committees = None
 
+        date_fields = {
+            'first_file_date': '%Y-%m-%d',
+            'last_f2_date': '%Y-%m-%d',
+            'last_file_date': '%Y-%m-%d',
+            'load_date': '%Y-%m-%dT%H:%M:%S',
+            }
+
         for k, v in kwargs.items():
-            setattr(self, k, v)
+            utils.set_instance_attr(self, k, v, date_fields)
 
     def __unicode__(self):
         return unicode("{name} {id}".format(name=self.name,
@@ -88,8 +95,15 @@ class CandidateHistoryPeriod(utils.PyOpenFecApiPaginatedClass):
         self.state = None
         self.two_year_period = None
 
+        date_fields = {
+            'first_file_date': '%Y-%m-%d',
+            'last_f2_date': '%Y-%m-%d',
+            'last_file_date': '%Y-%m-%d',
+            'load_date': '%Y-%m-%dT%H:%M:%S',
+            }
+
         for k, v in kwargs.items():
-            setattr(self, k, v)
+            utils.set_instance_attr(self, k, v, date_fields)
 
     def __unicode__(self):
         return unicode("{name} [{cand_id}] ({period})".format(

--- a/pyopenfec/committee.py
+++ b/pyopenfec/committee.py
@@ -29,8 +29,14 @@ class Committee(utils.PyOpenFecApiPaginatedClass, utils.SearchMixin):
         self._history = None
         self._totals = None
 
+        date_fields = {
+            'first_file_date': '%Y-%m-%d',
+            'last_f1_date': '%Y-%m-%d',
+            'last_file_date': '%Y-%m-%d',
+            }
+
         for k, v in kwargs.items():
-            setattr(self, k, v)
+            utils.set_instance_attr(self, k, v, date_fields)
 
     def __unicode__(self):
         return unicode("{name} {id}".format(name=self.name,

--- a/pyopenfec/filing.py
+++ b/pyopenfec/filing.py
@@ -44,8 +44,15 @@ class Filing(utils.PyOpenFecApiPaginatedClass):
         self.treasurer_name = None
         self.update_date = None
 
+        date_fields = {
+            'coverage_end_date': '%Y-%m-%dT%H:%M:%S',
+            'coverage_start_date': '%Y-%m-%dT%H:%M:%S',
+            'receipt_date': '%Y-%m-%dT%H:%M:%S',
+            'update_date': '%Y-%m-%dT%H:%M:%S',
+            }
+
         for k, v in kwargs.items():
-            setattr(self, k, v)
+            utils.set_instance_attr(self, k, v, date_fields)
 
     def __unicode__(self):
         return unicode("{cid}'s #{fn} Form {ft} ({rtf})".format(fn=self.file_number,

--- a/pyopenfec/report.py
+++ b/pyopenfec/report.py
@@ -182,8 +182,14 @@ class Report(utils.PyOpenFecApiPaginatedClass):
         self.transfers_to_other_authorized_committee_period = None
         self.transfers_to_other_authorized_committee_ytd = None
 
+        date_fields = {
+            'coverage_end_date': '%Y-%m-%dT%H:%M:%S+00:00',
+            'coverage_start_date': '%Y-%m-%dT%H:%M:%S+00:00',
+            'receipt_date': '%Y-%m-%dT%H:%M:%S',
+            }
+
         for k, v in kwargs.items():
-            setattr(self, k, v)
+            utils.set_instance_attr(self, k, v, date_fields)
 
     def __unicode__(self):
         return unicode("{cid} {rtf} ({c} cycle, {csd}-{ced})".format(

--- a/pyopenfec/transaction.py
+++ b/pyopenfec/transaction.py
@@ -57,8 +57,14 @@ class ScheduleATransaction(utils.PyOpenFecApiIndexedClass):
         self.transaction_id = None
         self.update_date = None
 
+        date_fields = {
+            'contribution_receipt_date': '%Y-%m-%dT%H:%M:%S',
+            'load_date': '%Y-%m-%dT%H:%M:%S.%f+00:00',
+            'timestamp': '%Y-%m-%dT%H:%M:%S.%f+00:00',
+            }
+
         for k, v in kwargs.items():
-            setattr(self, k, v)
+            utils.set_instance_attr(self, k, v, date_fields)
 
     @classmethod
     def fetch(cls, **kwargs):
@@ -133,8 +139,13 @@ class ScheduleBTransaction(utils.PyOpenFecApiIndexedClass):
         self.transaction_id = None
         self.update_date = None
 
+        date_fields = {
+            'disbursement_date': '%Y-%m-%dT%H:%M:%S',
+            'load_date': '%Y-%m-%dT%H:%M:%S.%f+00:00',
+            }
+
         for k, v in kwargs.items():
-            setattr(self, k, v)
+            utils.set_instance_attr(self, k, v, date_fields)
 
     @classmethod
     def fetch(cls, **kwargs):

--- a/pyopenfec/utils.py
+++ b/pyopenfec/utils.py
@@ -2,9 +2,11 @@ import json
 import os
 import time
 import logging
+from datetime import datetime
 
 import requests
 import six
+from pytz import timezone
 
 if six.PY2:
     from exceptions import Exception, NotImplementedError, TypeError
@@ -14,6 +16,7 @@ API_KEY = os.environ.get('OPENFEC_API_KEY', None)
 BASE_URL = 'https://api.open.fec.gov'
 VERSION = '/v1'
 
+eastern = timezone('US/Eastern')
 
 class PyOpenFecException(Exception):
     """
@@ -182,3 +185,12 @@ def default_empty_list(func):
         except TypeError:
             return []
     return inner
+
+
+def set_instance_attr(instance, k, v, date_fields):
+    if k in date_fields and v is not None:
+        parsed_date = datetime.strptime(v, date_fields[k])
+        tz_aware = eastern.localize(parsed_date)
+        setattr(instance, k, tz_aware)
+        return
+    setattr(instance, k, v)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 nose==1.3.7
 requests==2.7.0
 six==1.9.0
+pytz==2018.4

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@
 from setuptools import setup, find_packages
 
 setup(name="pyopenfec",
-      version="0.2.0",
+      version="0.2.1",
       description="OpenFEC API client",
       license="MIT",
-      install_requires=["requests", "six"],
+      install_requires=["pytz", "requests", "six"],
       author="Jeremy Bowers",
       author_email="jeremyjbowers@gmail.com",
       url="http://github.com/jeremyjbowers/pyopenfec",

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,86 @@
+import unittest
+from pyopenfec import Candidate, Committee
+from datetime import datetime
+
+
+class CandidateTest(unittest.TestCase):
+    def setUp(self):
+        self.candidate = None
+        candidates = Candidate.fetch(candidate_id='H8CA05035')
+        for candidate in candidates:
+            self.candidate = candidate
+
+    def test_candidate_dates(self):
+        self.assertIsInstance(self.candidate.first_file_date, datetime)
+        self.assertIsInstance(self.candidate.last_f2_date, datetime)
+        self.assertIsInstance(self.candidate.last_file_date, datetime)
+        self.assertIsInstance(self.candidate.load_date, datetime)
+
+    def test_history_dates(self):
+        history = self.candidate.history[2018]
+        self.assertIsInstance(history.first_file_date, datetime)
+        self.assertIsInstance(history.last_f2_date, datetime)
+        self.assertIsInstance(history.last_file_date, datetime)
+        self.assertIsInstance(history.load_date, datetime)
+
+
+class CommitteeTest(unittest.TestCase):
+    def setUp(self):
+        self.committee = None
+        committees = Committee.fetch(designation='P', candidate_id='H8CA05035')
+        for committee in committees:
+            self.committee = committee
+
+    def test_committee_dates(self):
+        self.assertIsInstance(self.committee.first_file_date, datetime)
+        self.assertIsInstance(self.committee.last_f1_date, datetime)
+        self.assertIsInstance(self.committee.last_file_date, datetime)
+
+    def test_committee_totals_dates(self):
+        totals = self.committee.totals[2018]
+        self.assertIsInstance(totals.coverage_end_date, datetime)
+        self.assertIsInstance(totals.coverage_start_date, datetime)
+
+    def test_filing_dates(self):
+        example_filing = None
+        for filing in self.committee.select_filings(file_number=1186352):
+            example_filing = filing
+        self.assertIsInstance(example_filing.coverage_end_date, datetime)
+        self.assertIsInstance(example_filing.coverage_start_date, datetime)
+        self.assertIsInstance(example_filing.receipt_date, datetime)
+        self.assertIsInstance(example_filing.update_date, datetime)
+
+    def test_report_dates(self):
+        example_report = None
+        for report in self.committee.select_reports(file_number=1234452):
+            example_report = report
+        self.assertIsInstance(example_report.coverage_end_date, datetime)
+        self.assertIsInstance(example_report.coverage_start_date, datetime)
+        self.assertIsInstance(example_report.receipt_date, datetime)
+
+    def test_schedule_a_dates(self):
+        example = None
+        donations = self.committee.select_receipts(
+            contributor_name='SANDBERG, SHERYL',
+            two_year_transaction_period=2018,
+            )
+        for donation in donations:
+            example = donation
+        self.assertIsInstance(example.contribution_receipt_date, datetime)
+        self.assertIsInstance(example.load_date, datetime)
+        self.assertIsInstance(example.timestamp, datetime)
+
+    def test_schedule_b_dates(self):
+        example = None
+        donations = self.committee.select_disbursements(
+            recipient_name='GOAT HILL PIZZA',
+            two_year_transaction_period=2018,
+            )
+        for donation in donations:
+            example = donation
+        self.assertIsInstance(example.disbursement_date, datetime)
+        self.assertIsInstance(example.load_date, datetime)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #12 

This PR makes the date fields of all the classes in this library be `datetime` objects and, perhaps more importantly, adds a `tests.py` file that tests all of these fields.

~~I looked into putting the parsing logic in utils.py as proposed in the issue. However, I ran into the problem that the OpenFEC API returns a number of formats for its various date fields. I considered adding a dependency on dateutil, but wanted to keep the list of dependencies to a minimum.~~

~~Also `yield cls(**result)` gets called in multiple places in utils.py. It seemed like less repetition to handle conversion from string to datetime in the constructor of every class than to iterate over every key of every result in multiple places in utils.py.~~

Update (6/15/2018) I just updated this PR to use a utility function for setting attributes of an an instance, provided an object of date fields, with the value being a format string that can be passed to datetime.strptime.

I'm definitely open to doing this another way, though. I'd love to hear your thoughts.