### PR TITLE
handle response when x-ratelimit-remaining not in headers

### DIFF
--- a/pyopenfec/utils.py
+++ b/pyopenfec/utils.py
@@ -72,6 +72,8 @@ class PyOpenFecApiClass(object):
                 response = requests.get(url, params=params)
                 if 'x-ratelimit-remaining' in response.headers:
                     cls.ratelimit_remaining = int(response.headers['x-ratelimit-remaining'])
+                elif response.status_code == 200:
+                    cls.ratelimit_remaining = 120
                 else:
                     cls.ratelimit_remaining = 0
 

--- a/pyopenfec/utils.py
+++ b/pyopenfec/utils.py
@@ -70,7 +70,10 @@ class PyOpenFecApiClass(object):
                         cls.wait_time))
                 time.sleep(cls.wait_time)
                 response = requests.get(url, params=params)
-                cls.ratelimit_remaining = int(response.headers['x-ratelimit-remaining'])
+                if 'x-ratelimit-remaining' in response.headers:
+                    cls.ratelimit_remaining = int(response.headers['x-ratelimit-remaining'])
+                else:
+                    cls.ratelimit_remaining = 0
 
         cls.wait_time = 0.5
         return response

--- a/pyopenfec/utils.py
+++ b/pyopenfec/utils.py
@@ -57,7 +57,10 @@ class PyOpenFecApiClass(object):
         response = None
         if not cls.ratelimit_remaining == 0:
             response = requests.get(url, params=params)
-            cls.ratelimit_remaining = int(response.headers['x-ratelimit-remaining'])
+            if 'x-ratelimit-remaining' in response.headers:
+                cls.ratelimit_remaining = int(response.headers['x-ratelimit-remaining'])
+            else:
+                cls.ratelimit_remaining = 1000
 
         if cls.ratelimit_remaining == 0 or response.status_code == 429:
             while cls.ratelimit_remaining == 0 or response.status_code == 429:


### PR DESCRIPTION
Fixes #25 

This PR adds handling for when the response returned from the openFEC API does not contain a `X-RateLimit-Remaining` header, which happens when the FEC increases your rate-limit.