### PR TITLE
Add trailing slash to urls to avoid redirects

### DIFF
--- a/pyopenfec/utils.py
+++ b/pyopenfec/utils.py
@@ -78,7 +78,7 @@ class PyOpenFecApiClass(object):
 
     @classmethod
     def _make_request(cls, resource, **kwargs):
-        url = BASE_URL + VERSION + '/%s' % resource
+        url = BASE_URL + VERSION + '/%s/' % resource
 
         if not API_KEY:
             raise PyOpenFecException('Please export an env var OPENFEC_API_KEY with your API key.')


### PR DESCRIPTION
I don't know if this is the result of a recent change to `api.open.fec.gov` or if it has always been that way, but currently requests to urls like `https://api.open.fec.gov/v1/candidates` get redirected to urls like `https://api.open.fec.gov/v1/candidates/` before they return a response. The `requests` library takes care of this for us by following redirects. Unfortunately, both the original request and the redirected request count against the user's API rate limit. That means users of the pyopenfec library can only make 500 meaningful requests per hour with the FEC's default 1000 request/hour rate limit.

This PR addresses the issue by adding a trailing slash when the url is created. This could potentially cause problems if either a `resource` has a trailing slash in it or if there is a resource on `api.open.fec.gov` that does not expect a trailing slash. However, currently there are instances of resources in the pyopenfec code base that have a trailing slash and all the resources listed at `https://api.open.fec.gov/developers/` contain a trailing slash.